### PR TITLE
fix更新数据后滑动，曲线跳转的问题

### DIFF
--- a/dist/wxcharts.js
+++ b/dist/wxcharts.js
@@ -1942,6 +1942,9 @@ var Charts = function Charts(opts) {
 Charts.prototype.updateData = function () {
     var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
+    if(this.opts.enableScroll == true) {
+        this.opts._scrollDistance_ = this.scrollOption.currentOffset;
+    }
     this.opts.series = data.series || this.opts.series;
     this.opts.categories = data.categories || this.opts.categories;
 


### PR DESCRIPTION
曲线切换时没有做offset的重置，导致scroll开始时候曲线会重新跳转到开头。
不会打包，直接patch到这里了～